### PR TITLE
Fix manual updates fail when disabled auto-update

### DIFF
--- a/content/addonsOverlay.js
+++ b/content/addonsOverlay.js
@@ -238,6 +238,17 @@ function addonExecutesNonLast(aAddon) {
       != aAddon.executionIndex) && addonExecutesRichlistitem(aAddon);
 }
 
+function addonUpdateCanBeAllowed(aAddon) {
+  if (!aAddon) {
+    return false;
+  }
+  if (aAddon.type != GM_CONSTANTS.scriptAddonType) {
+    return false;
+  }
+
+  return aAddon._script.isRemoteUpdateAllowed(false);
+}
+
 function addonUpdateCanBeForced(aAddon) {
   if (!aAddon) {
     return false;
@@ -308,6 +319,14 @@ function init() {
       }
     };
 
+  gViewController.commands.cmd_userscript_manualFindItemUpdates = {
+      "isEnabled": addonUpdateCanBeAllowed,
+      "doCommand": function (aAddon) {
+        aAddon.manualUpdate = true;
+        gViewController.commands.cmd_findItemUpdates.doCommand(aAddon);
+        aAddon.manualUpdate = false;
+      }
+  };
   gViewController.commands.cmd_userscript_forcedFindItemUpdates = {
       "isEnabled": addonUpdateCanBeForced,
       "doCommand": function (aAddon) {

--- a/content/addonsOverlay.xul
+++ b/content/addonsOverlay.xul
@@ -33,6 +33,7 @@
   <command id="cmd_userscript_execute_later" />
   <command id="cmd_userscript_execute_last" />
   <command id="cmd_userscript_showItemPreferences" />
+  <command id="cmd_userscript_manualFindItemUpdates" />
   <command id="cmd_userscript_forcedFindItemUpdates" />
 </commandset>
 
@@ -54,7 +55,7 @@
   <menuseparator class="greasemonkey" />
 
   <!-- Default find updates item. -->
-  <menuitem command="cmd_findItemUpdates" class="greasemonkey"
+  <menuitem command="cmd_userscript_manualFindItemUpdates" class="greasemonkey"
     label="&cmd.findUpdates.label;" accesskey="&cmd.findUpdates.accesskey;" />
   <!-- Custom forced find updates item. -->
   <menuitem command="cmd_userscript_forcedFindItemUpdates" class="greasemonkey"

--- a/content/addonsOverlay.xul
+++ b/content/addonsOverlay.xul
@@ -54,7 +54,7 @@
 
   <menuseparator class="greasemonkey" />
 
-  <!-- Default find updates item. -->
+  <!-- NOT default "cmd_findItemUpdates", use ourselves find updates item. -->
   <menuitem command="cmd_userscript_manualFindItemUpdates" class="greasemonkey"
     label="&cmd.findUpdates.label;" accesskey="&cmd.findUpdates.accesskey;" />
   <!-- Custom forced find updates item. -->

--- a/modules/addons.js
+++ b/modules/addons.js
@@ -340,7 +340,7 @@ ScriptAddon.prototype.isCompatibleWith = function () {
  */
 ScriptAddon.prototype.findUpdates = function (aUpdateListener, aReason) {
   let callback = GM_util.hitch(this, this._handleRemoteUpdate, aUpdateListener);
-  this._script.checkForRemoteUpdate(callback, this.forceUpdate);
+  this._script.checkForRemoteUpdate(callback, this.forceUpdate, this.manualUpdate);
 };
 
 /**

--- a/modules/script.js
+++ b/modules/script.js
@@ -1361,8 +1361,9 @@ Script.prototype.shouldAutoUpdate = function () {
  * @param {function} aCallback - Called with ("updateAvailable") or
  *   ("noUpdateAvailable", infoObj) when the check completes.
  * @param {boolean}  aForced   - If true, bypasses auto-update and enabled checks.
+ * @param {boolean}  aManual   - If true, bypasses auto-update checks.
  */
-Script.prototype.checkForRemoteUpdate = function (aCallback, aForced) {
+Script.prototype.checkForRemoteUpdate = function (aCallback, aForced, aManual) {
   if (this.availableUpdate) {
     return aCallback("updateAvailable");
   }
@@ -1381,7 +1382,7 @@ Script.prototype.checkForRemoteUpdate = function (aCallback, aForced) {
   }
 
   let _shouldAutoUpdate = this.shouldAutoUpdate();
-  if (!aForced && !_shouldAutoUpdate) {
+  if (!aManual && !aForced && !_shouldAutoUpdate) {
     return aCallback("noUpdateAvailable", {
       "name": this.localized.name,
       "fileURL": this.fileURL,
@@ -1490,7 +1491,7 @@ Script.prototype.checkForRemoteUpdate = function (aCallback, aForced) {
   // Let the server know we want a user script metadata block.
   req.setRequestHeader("Accept", "text/x-userscript-meta");
   req.onload = GM_util.hitch(
-      this, "checkRemoteVersion", req, aCallback, aForced, usedMeta);
+      this, "checkRemoteVersion", req, aCallback, aForced, aManual, usedMeta);
   req.onerror = GM_util.hitch(null, aCallback, "noUpdateAvailable", {
     "name": this.localized.name,
     "fileURL": this.fileURL,
@@ -1533,15 +1534,16 @@ Script.prototype.checkForRemoteUpdate = function (aCallback, aForced) {
  * @param {XMLHttpRequest} aReq      - The completed XHR.
  * @param {function}       aCallback - Forwarded from checkForRemoteUpdate.
  * @param {boolean}        aForced   - Forwarded from checkForRemoteUpdate.
+ * @param {boolean}        aManual   - Forwarded from checkForRemoteUpdate.
  * @param {boolean}        aMeta     - True if this was a .meta.js request.
  */
 Script.prototype.checkRemoteVersion = function (
-    aReq, aCallback, aForced, aMeta) {
+    aReq, aCallback, aForced, aManual, aMeta) {
   let metaFail = GM_util.hitch(this, function () {
     this._updateMetaStatus = UPDATE_META_STATUS_FAIL;
     this._changed("modified", null);
 
-    return this.checkForRemoteUpdate(aCallback, aForced);
+    return this.checkForRemoteUpdate(aCallback, aForced, aManual);
   });
 
   if ((aReq.status != 200) && (aReq.status != 0)) {


### PR DESCRIPTION
- add new command `cmd_userscript_manualFindItemUpdates` instead of `cmd_findItemUpdates`.
- add param aManual to check funtions (`checkForRemoteUpdate` / `checkRemoteVersion`).

close #4